### PR TITLE
Don't mention to committer in changelong

### DIFF
--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -93,7 +93,7 @@ export function renderChangeLog(
       }
 
       if (options.showCommitter) {
-        fields.push(`- by @${c.committer}`)
+        fields.push(`- by ${c.committer}`)
       }
 
       return fields.join(' ')


### PR DESCRIPTION
Fixes https://github.com/pipe-cd/actions-gh-release/issues/7

For now we settled on just stoping mentioning to the committer as a workaround.