### PR TITLE
Add release name to release config

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ tag: v0.1.0                       # The tag number will be created. Required.
 
 # # Optional fields:
 #
-# title: string                   # The release tile. Default is "Release ${tag}".
+# name: string                    # The release name. Default is empty.
+# title: string                   # The release title. Default is "Release ${tag}".
 # targetCommitish: string         # The release commitish. Default is the merged commit.
 # releaseNote: string             # The release body. Default is the auto-generated release note.
 # prerelease: bool                # True if this is a prerelease. Default is false.
@@ -132,6 +133,7 @@ releaseNoteGenerator:
 
 ``` yaml
 tag: foo-v0.1.0
+name: foo
 
 commitInclude:
   contains:

--- a/release.go
+++ b/release.go
@@ -31,6 +31,7 @@ var (
 
 type ReleaseConfig struct {
 	Tag             string `json:"tag,omitempty"`
+	Name            string `json:"name,omitempty"`
 	Title           string `json:"title,omitempty"`
 	TargetCommitish string `json:"targetCommitish,omitempty"`
 	ReleaseNote     string `json:"releaseNote,omitempty"`
@@ -115,6 +116,7 @@ func parseReleaseConfig(data []byte) (*ReleaseConfig, error) {
 
 type ReleaseProposal struct {
 	Tag             string `json:"tag,omitempty"`
+	Name            string `json:"name,omitempty"`
 	Title           string `json:"title,omitempty"`
 	TargetCommitish string `json:"targetCommitish,omitempty"`
 	ReleaseNote     string `json:"releaseNote,omitempty"`
@@ -163,6 +165,7 @@ func buildReleaseProposal(ctx context.Context, releaseFile string, gitExecPath, 
 	releaseCommits := buildReleaseCommits(commits, *headCfg)
 	p := ReleaseProposal{
 		Tag:             headCfg.Tag,
+		Name:            headCfg.Name,
 		Title:           headCfg.Title,
 		TargetCommitish: headCfg.TargetCommitish,
 		ReleaseNote:     headCfg.ReleaseNote,

--- a/release_test.go
+++ b/release_test.go
@@ -39,6 +39,7 @@ func TestParseReleaseConfig(t *testing.T) {
 			configFile: "testdata/valid-config.txt",
 			expected: &ReleaseConfig{
 				Tag: "v1.1.0",
+				Name: "hello",
 				CommitInclude: ReleaseCommitMatcherConfig{
 					Contains: []string{
 						"app/hello",
@@ -100,6 +101,7 @@ func TestParseReleaseConfig(t *testing.T) {
 func TestBuildReleaseCommits(t *testing.T) {
 	config := ReleaseConfig{
 		Tag: "v1.1.0",
+		Name: "hello",
 		CommitInclude: ReleaseCommitMatcherConfig{
 			Contains: []string{
 				"app/hello",

--- a/testdata/valid-config.txt
+++ b/testdata/valid-config.txt
@@ -1,4 +1,5 @@
 tag: v1.1.0
+name: hello
 
 commitInclude:
   contains:


### PR DESCRIPTION
Added an option to represent the application name in Multiple RELEASE files for mono-repo style. This option will be output as `outputs.releases[].name` and can be used by external services such as fourkeys to identify the target application.