### PR TITLE
Add usePullRequestMetadata option to use PR metadata instead of commit message

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,56 +9,57 @@ An action that enables operating GitHub release via pull request. You send a pul
 - Adding a RELEASE file to the repository. You can also have multiple RELEASE files in case of monorepo style. Its content looks like this:
 
 ``` yaml
-tag: v0.1.0                       # The tag number will be created. Required.
+tag: v0.1.0                        # The tag number will be created. Required.
 
 # # Optional fields:
 #
-# name: string                    # The release name. Default is empty.
-# title: string                   # The release title. Default is "Release ${tag}".
-# targetCommitish: string         # The release commitish. Default is the merged commit.
-# releaseNote: string             # The release body. Default is the auto-generated release note.
-# prerelease: bool                # True if this is a prerelease. Default is false.
+# name: string                     # The release name. Default is empty.
+# title: string                    # The release title. Default is "Release ${tag}".
+# targetCommitish: string          # The release commitish. Default is the merged commit.
+# releaseNote: string              # The release body. Default is the auto-generated release note.
+# prerelease: bool                 # True if this is a prerelease. Default is false.
 #
 #
 # # If specified, all matching commits will be excluded from release. Empty means excluding nothing.
 #
 # commitExclude:
-#   parentOfMergeCommit: bool     # True is whether the commit is the parent commit of the matching merge commit. Default is false.
-#   prefixes: []string            # Matches if commit's subject is prefixed by one of the given values. Default is emtpy.
-#   contains: []string            # Matches if commit's body is containing one of the given values. Default is emtpy.
+#   parentOfMergeCommit: bool      # True is whether the commit is the parent commit of the matching merge commit. Default is false.
+#   prefixes: []string             # Matches if commit's subject is prefixed by one of the given values. Default is emtpy.
+#   contains: []string             # Matches if commit's body is containing one of the given values. Default is emtpy.
 #
 #
 # # If specified, all matching commits will be included to release. Empty means including alls.
 #
 # commitInclude:
-#   parentOfMergeCommit: bool     # True is whether the commit is the parent commit of the matching merge commit. Default is false.
-#   prefixes: []string            # Matches if commit's subject is prefixed by one of the given values. Default is emtpy.
-#   contains: []string            # Matches if commit's body is containing one of the given values. Default is emtpy.
+#   parentOfMergeCommit: bool      # True is whether the commit is the parent commit of the matching merge commit. Default is false.
+#   prefixes: []string             # Matches if commit's subject is prefixed by one of the given values. Default is emtpy.
+#   contains: []string             # Matches if commit's body is containing one of the given values. Default is emtpy.
 #
 #
 # # List of categories and how to decide which category a commit should belong to.
 #
 # commitCategories:
-#   - title: string               # Category title.
-#     parentOfMergeCommit: bool   # True is whether the commit is the parent commit of the matching merge commit. Default is false.
-#     contains: []string          # Matches if commit's subject is prefixed by one of the given values. Default is emtpy.
-#     prefixes: []string          # Matches if commit's body is containing one of the given values. Default is emtpy.
+#   - title: string                # Category title.
+#     parentOfMergeCommit: bool    # True is whether the commit is the parent commit of the matching merge commit. Default is false.
+#     contains: []string           # Matches if commit's subject is prefixed by one of the given values. Default is emtpy.
+#     prefixes: []string           # Matches if commit's body is containing one of the given values. Default is emtpy.
 #
 #
 # # Config used while generating release note.
 #
 # releaseNoteGenerator:
-#   showAbbrevHash: bool          # Whether to include abbreviated hash value in release note. Default is false.
-#   showCommitter: bool           # Whether to include committer in release note. Default is true.
-#   useReleaseNoteBlock: bool     # Whether to use release note block instead of commit message. Default is false.
-#   commitExclude:                # Additional excludes applied while generating release note.
-#     parentOfMergeCommit: bool   # True is whether the commit is the parent commit of the matching merge commit. Default is false.
-#     prefixes: []string          # Matches if commit's subject is prefixed by one of the given values. Default is emtpy.
-#     contains: []string          # Matches if commit's body is containing one of the given values. Default is emtpy.
-#   commitInclude:                # Additional includes applied while generating release note.
-#     parentOfMergeCommit: bool   # True is whether the commit is the parent commit of the matching merge commit. Default is false.
-#     prefixes: []string          # Matches if commit's subject is prefixed by one of the given values. Default is emtpy.
-#     contains: []string          # Matches if commit's body is containing one of the given values. Default is emtpy.
+#   showAbbrevHash: bool           # Whether to include abbreviated hash value in release note. Default is false.
+#   showCommitter: bool            # Whether to include committer in release note. Default is true.
+#   useReleaseNoteBlock: bool      # Whether to use release note block instead of commit message. Default is false.
+#   usePullRequestMetadata: bool   # Whether to use pull request metadata instead of commit message when using merge-commit. If useReleaseNoteBlock is also true, release note block of pull request is used. Otherwise pull request title is used. If this option is set, showAbbrevHash and showCommitter is ignored. Default is false.
+#   commitExclude:                 # Additional excludes applied while generating release note.
+#     parentOfMergeCommit: bool    # True is whether the commit is the parent commit of the matching merge commit. Default is false.
+#     prefixes: []string           # Matches if commit's subject is prefixed by one of the given values. Default is emtpy.
+#     contains: []string           # Matches if commit's body is containing one of the given values. Default is emtpy.
+#   commitInclude:                 # Additional includes applied while generating release note.
+#     parentOfMergeCommit: bool    # True is whether the commit is the parent commit of the matching merge commit. Default is false.
+#     prefixes: []string           # Matches if commit's subject is prefixed by one of the given values. Default is emtpy.
+#     contains: []string           # Matches if commit's body is containing one of the given values. Default is emtpy.
 ```
 
 - Adding a new workflow (eg: `.github/workflows/gh-release.yaml`) with the content as below:

--- a/git.go
+++ b/git.go
@@ -55,6 +55,24 @@ func (c Commit) IsMerge() bool {
 	return len(c.ParentHashes) == 2
 }
 
+func (c Commit) PullRequestNumber() (int, bool) {
+	if !c.IsMerge() {
+		return 0, false
+	}
+
+	subs := defaultMergeCommitRegex.FindStringSubmatch(c.Subject)
+	if len(subs) != 2 {
+		return 0, false
+	}
+
+	prNumber, err := strconv.Atoi(subs[1])
+	if err != nil {
+		return 0, false
+	}
+
+	return prNumber, true
+}
+
 func parseCommits(log string) ([]Commit, error) {
 	lines := strings.Split(log, separator)
 	if len(lines) < 1 {

--- a/release_test.go
+++ b/release_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -99,6 +100,7 @@ func TestParseReleaseConfig(t *testing.T) {
 }
 
 func TestBuildReleaseCommits(t *testing.T) {
+	ctx := context.Background()
 	config := ReleaseConfig{
 		Tag:  "v1.1.0",
 		Name: "hello",
@@ -151,10 +153,12 @@ func TestBuildReleaseCommits(t *testing.T) {
 		commits  []Commit
 		config   ReleaseConfig
 		expected []ReleaseCommit
+		wantErr  bool
 	}{
 		{
 			name:     "empty",
 			expected: []ReleaseCommit{},
+			wantErr:  false,
 		},
 		{
 			name: "ok",
@@ -215,6 +219,7 @@ func TestBuildReleaseCommits(t *testing.T) {
 					ReleaseNote:  "Commit 4 release note",
 				},
 			},
+			wantErr: false,
 		},
 		{
 			name: "Add include condition: parent of merge commit",
@@ -286,12 +291,14 @@ func TestBuildReleaseCommits(t *testing.T) {
 					ReleaseNote:  "Commit 3 message",
 				},
 			},
+			wantErr: false,
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := buildReleaseCommits(tc.commits, tc.config)
+			got, err := buildReleaseCommits(ctx, nil, tc.commits, tc.config, nil)
+			assert.Equal(t, tc.wantErr, err != nil)
 			assert.Equal(t, tc.expected, got)
 		})
 	}


### PR DESCRIPTION
## Overview
It enable to create release note to use PR's release block or PR's title instead of commit messages.

## Issue
https://github.com/pipe-cd/actions-gh-release/issues/22

## Note
### Rate limit
This implementation call github REAT API in order to get PR metadata per merge-commit.
Hence, If one release contains a lot of merge-commits or you release really frequently, it’s possible to exceed the rate limit.
ref: [Request from Github Action](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#requests-from-github-actions)
```
When using GITHUB_TOKEN, the rate limit is 1,000 requests per hour per repository.
For requests to resources that belong to an enterprise account on GitHub.com,
GitHub Enterprise Cloud's rate limit applies, and the limit is 15,000 requests per hour per repository.
```
