### PR TITLE
fix: behavior with usePullRequestMetadata option

### DIFF
--- a/release.go
+++ b/release.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"regexp"
 	"strings"
 
@@ -266,7 +267,7 @@ func buildReleaseCommits(ctx context.Context, ghClient *githubClient, commits []
 		}
 		pr, err := ghClient.getPullRequest(ctx, event.Owner, event.Repo, prNumber)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to get pull request by number %d: %v", prNumber, err)
 		}
 		return pr, nil
 	}
@@ -293,7 +294,8 @@ func buildReleaseCommits(ctx context.Context, ghClient *githubClient, commits []
 		if gen.UsePullRequestMetadata {
 			pr, err := getPullRequest(commit)
 			if err != nil {
-				return nil, err
+				// only error logging, ignore error
+				log.Printf("Failed to get pull request: %v\n", err)
 			}
 			if pr != nil {
 				c.PullRequestNumber = pr.GetNumber()

--- a/release.go
+++ b/release.go
@@ -235,7 +235,8 @@ func buildReleaseCommits(ctx context.Context, ghClient *githubClient, commits []
 	}
 
 	gen, limit := cfg.ReleaseNoteGenerator, 1000
-	prs := make(map[int]*github.PullRequest, limit)
+	shaPRs := make(map[string]*github.PullRequest, limit)
+	numPRs := make(map[int]*github.PullRequest, limit)
 	if gen.UsePullRequestMetadata {
 		opts := &ListPullRequestOptions{
 			State:     PullRequestStateClosed,
@@ -248,9 +249,32 @@ func buildReleaseCommits(ctx context.Context, ghClient *githubClient, commits []
 			return nil, err
 		}
 		for i := range v {
+			sha := *v[i].MergeCommitSHA
+			shaPRs[sha] = v[i]
 			number := *v[i].Number
-			prs[number] = v[i]
+			numPRs[number] = v[i]
 		}
+	}
+
+	getPullRequest := func(commit Commit) (*github.PullRequest, error) {
+		if !commit.IsMerge() {
+			return nil, nil
+		}
+		if pr, ok := shaPRs[commit.Hash]; ok {
+			return pr, nil
+		}
+		prNumber, ok := commit.PullRequestNumber()
+		if !ok {
+			return nil, nil
+		}
+		if pr, ok := numPRs[prNumber]; ok {
+			return pr, nil
+		}
+		pr, err := ghClient.getPullRequest(ctx, event.Owner, event.Repo, prNumber)
+		if err != nil {
+			return nil, err
+		}
+		return pr, nil
 	}
 
 	out := make([]ReleaseCommit, 0, len(commits))
@@ -273,22 +297,15 @@ func buildReleaseCommits(ctx context.Context, ghClient *githubClient, commits []
 		}
 
 		if gen.UsePullRequestMetadata {
-			prNumber, ok := commit.PullRequestNumber()
-			if !ok {
-				continue
-			}
-			c.PullRequestNumber = prNumber
-
-			var err error
-			pr, ok := prs[prNumber]
-			if !ok {
-				pr, err = ghClient.getPullRequest(ctx, event.Owner, event.Repo, prNumber)
-			}
+			pr, err := getPullRequest(commit)
 			if err != nil {
 				return nil, err
 			}
-			c.PullRequestOwner = pr.GetUser().GetLogin()
-			c.ReleaseNote = extractReleaseNote(pr.GetTitle(), pr.GetBody(), gen.UseReleaseNoteBlock)
+			if pr != nil {
+				c.PullRequestNumber = pr.GetNumber()
+				c.PullRequestOwner = pr.GetUser().GetLogin()
+				c.ReleaseNote = extractReleaseNote(pr.GetTitle(), pr.GetBody(), gen.UseReleaseNoteBlock)
+			}
 		}
 
 		out = append(out, c)

--- a/release.go
+++ b/release.go
@@ -235,8 +235,7 @@ func buildReleaseCommits(ctx context.Context, ghClient *githubClient, commits []
 	}
 
 	gen, limit := cfg.ReleaseNoteGenerator, 1000
-	shaPRs := make(map[string]*github.PullRequest, limit)
-	numPRs := make(map[int]*github.PullRequest, limit)
+	prs := make(map[string]*github.PullRequest, limit)
 	if gen.UsePullRequestMetadata {
 		opts := &ListPullRequestOptions{
 			State:     PullRequestStateClosed,
@@ -250,9 +249,7 @@ func buildReleaseCommits(ctx context.Context, ghClient *githubClient, commits []
 		}
 		for i := range v {
 			sha := *v[i].MergeCommitSHA
-			shaPRs[sha] = v[i]
-			number := *v[i].Number
-			numPRs[number] = v[i]
+			prs[sha] = v[i]
 		}
 	}
 
@@ -260,15 +257,12 @@ func buildReleaseCommits(ctx context.Context, ghClient *githubClient, commits []
 		if !commit.IsMerge() {
 			return nil, nil
 		}
-		if pr, ok := shaPRs[commit.Hash]; ok {
+		if pr, ok := prs[commit.Hash]; ok {
 			return pr, nil
 		}
 		prNumber, ok := commit.PullRequestNumber()
 		if !ok {
 			return nil, nil
-		}
-		if pr, ok := numPRs[prNumber]; ok {
-			return pr, nil
 		}
 		pr, err := ghClient.getPullRequest(ctx, event.Owner, event.Repo, prNumber)
 		if err != nil {


### PR DESCRIPTION
Enabling the `usePullRequestMetadata` option of the `releaseNoteGenerator` is causing a behavior that limits Release Commits to Merge Commits. 

However, we believe that this option should only affect Release Note generation. Therefore, we have modified the process to add metadata used for Release Note to Release Commit when this option is enabled.

In our use case we treat Release Commits as Metrics to be sent to FourKeys, so we need all the commits in the release.