### PR TITLE
fix: nil pointer reference when merge commit was not generated.

### DIFF
--- a/release.go
+++ b/release.go
@@ -249,7 +249,12 @@ func buildReleaseCommits(ctx context.Context, ghClient *githubClient, commits []
 			return nil, err
 		}
 		for i := range v {
-			sha := *v[i].MergeCommitSHA
+			sha := v[i].GetMergeCommitSHA()
+			// if merge commit sha is empty, the test merge commit was not generated.
+			// this cause when PR is conflict and closed without resolved.
+			if sha == "" {
+				continue
+			}
 			prs[sha] = v[i]
 		}
 	}


### PR DESCRIPTION
### Summary
fix a condition where nil pointer reference occurs

### About
If the pull request is closed with a conflict, a nil reference will occur because the test merge commit is not created.

### Reference
- https://docs.github.com/en/rest/guides/getting-started-with-the-git-database-api#checking-mergeability-of-pull-requests