### PR TITLE
fix comment in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-https://github.com/pipe-cd/pipecd/pkgs/container/actions-gh-release/68659129?tag=v0.41.4
+# https://github.com/pipe-cd/pipecd/pkgs/container/actions-gh-release/68659129?tag=v0.41.4
 FROM ghcr.io/pipe-cd/actions-gh-release@sha256:c69f4679811ba26391b494a318cda3c5e03408d9ae5208c471de760e0b5c7445


### PR DESCRIPTION
## Description
Fixed a build failure in v2.5.0 due to an uncommented section(L1 in Dockerfile) that should have been commented out.
