### PR TITLE
Add GITHUB_TOKEN permissions to actions-gh-release README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ on:
 jobs:
   gh-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write      # Required to create a GitHub release and tag, as GITHUB_TOKEN is read-only by default.
+      pull-requests: write # Required to comment the release note on the pull request.
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
### What This PR Does
This PR updates the `README.md` for `actions-gh-release` to include the required `GITHUB_TOKEN` permissions (`contents: write` and `pull-requests: write`) in the Usage section. GitHub’s default token is read-only, so these permissions are needed to create releases and comment on pull requests.

### Changes
- Modified the workflow example in the Usage section to include the `permissions` block with `contents: write` and `pull-requests: write`.
- Added a note explaining why these permissions are required.

### Issue
Fixes https://github.com/pipe-cd/pipecd/issues/4914